### PR TITLE
Open exact package instead of pub.dev

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ function startSearch(packageName: string) {
 	}
 	// https://pub.dartlang.org/packages?q=path
 	var tempUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
-	let searchUrl = tempUrl + 'packages?q=' + encodeURI(packageName);
+	let searchUrl = tempUrl + 'packages/' + encodeURI(packageName);
 	vscode.env.openExternal(vscode.Uri.parse(searchUrl));
 }
 


### PR DESCRIPTION
This PR will open the exact package in pub.dev instead of opening a tab with the search result for the package. Please verify it from your end as well beforing updating the package.